### PR TITLE
Update latitude and longitude names

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Requests are made with HTTP GET and the **vehicle-monitoring** endpoint.
 | operator_name     |    String       |   
 | vehicle_id        |    UID          |   
 | marker_time       |    ISO 8601     |   
-| longitude-x       |    Float        |  
-| latitude-y        |    Float        |   
+| longitude_x       |    Float        |  
+| latitude_y        |    Float        |   
 | vehicle_type      |    Enum         |   
 | vehicle_activity  |    Enum         |  
 


### PR DESCRIPTION
The README "Data Specification" section specifies these as `longitude-x` and `latitude-y` using `-` but the schema.json and README data example specify these as `longitude_x` and `latitude_y` with `_`.